### PR TITLE
[Cadastros] Estrutura de cadastros

### DIFF
--- a/app/Http/Controllers/ClientesController.php
+++ b/app/Http/Controllers/ClientesController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\FakeModel;
 use App\Traits\MontarPagina;
+use App\Traits\MontarForm;
 use Illuminate\Http\Request;
 use Illuminate\Support\Fluent;
 use Faker\Factory as Faker;
@@ -13,6 +14,7 @@ class ClientesController extends Controller
 	protected $prefix;
 
 	use MontarPagina;
+	use MontarForm;
 
 	public function __construct()
 	{
@@ -53,5 +55,12 @@ class ClientesController extends Controller
 		[$config, $header] = $this->montarPagina('cliente');
 
 		return view('listagem.tableList', compact('dados', 'config', 'header'));
+	}
+
+	public function cadastro(){
+
+		$dados = $this->montarForm('cliente');
+
+		return view('cadastro', compact('dados'));
 	}
 }

--- a/app/Traits/MontarForm.php
+++ b/app/Traits/MontarForm.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Support\Fluent;
+
+trait MontarForm
+{
+  public function montarForm($tipo)
+  {
+    return match ($tipo) {
+      'cliente' => $this->montarFormCliente(),
+    };
+  }
+
+  private function montarFormCliente()
+  {
+    $data = new Fluent([
+        'pageInfo' => [
+            'title' => 'Cadastrar cliente',
+            'form_action' => '',
+            'form_method' => '',
+            'label_button' => 'Cadastrar cliente',
+        ],
+        'sessions' => [
+            'Dados da Empresa' => [
+                'cpf' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-6',
+                    'label' => 'CPF/CNPJ',
+                    'type' => 'text',
+                    'placeholder' => '00.000.000/0001-00',
+                    'maxlength' => 18,
+                    'required' => true,
+                    'id' => 'cpfcnpj',
+                    'name' => 'cpfcnpj',
+                    'function' => false,
+                ],
+                'apelido' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-6',
+                    'label' => 'Apelido',
+                    'type' => 'text',
+                    'placeholder' => '',
+                    'maxlength' => 50,
+                    'required' => false,
+                    'id' => 'apelido',
+                    'name' => 'apelido',
+                    'function' => false,
+                ],
+                'razao_social' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-6',
+                    'label' => 'Razão Social',
+                    'type' => 'text',
+                    'placeholder' => '',
+                    'maxlength' => 70,
+                    'required' => true,
+                    'id' => 'razao',
+                    'name' => 'razao',
+                    'function' => false,
+                ],
+                'nome_fantasia' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-6',
+                    'label' => 'Nome Fantasia',
+                    'type' => 'text',
+                    'placeholder' => '',
+                    'maxlength' => 70,
+                    'required' => true,
+                    'id' => 'nome_fantasia',
+                    'name' => 'nome_fantasia',
+                    'function' => false,
+                ],
+                'cep' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-3',
+                    'label' => 'CEP',
+                    'type' => 'number',
+                    'placeholder' => '00000-000',
+                    'maxlength' => 9,
+                    'required' => true,
+                    'id' => 'cep',
+                    'name' => 'cep',
+                    'function' => [
+                        'type' => 'onChange',
+                        'name' => 'pesquisaCep()',
+                    ],
+                ],
+                'logradouro' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-7',
+                    'label' => 'Logradouro',
+                    'type' => 'text',
+                    'placeholder' => '',
+                    'maxlength' => 50,
+                    'required' => true,
+                    'id' => 'logradouro',
+                    'name' => 'logradouro',
+                    'function' => false,
+                ],
+                'numero' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-2',
+                    'label' => 'Número',
+                    'type' => 'number',
+                    'placeholder' => '123',
+                    'maxlength' => 10,
+                    'required' => true,
+                    'id' => 'numero',
+                    'name' => 'numero',
+                    'function' => false,
+                ],
+                'bairro' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-4',
+                    'label' => 'Bairro',
+                    'type' => 'text',
+                    'placeholder' => '',
+                    'maxlength' => 30,
+                    'required' => true,
+                    'id' => 'bairro',
+                    'name' => 'bairro',
+                    'function' => false,
+                ],
+                'cidade' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-4',
+                    'label' => 'Cidade',
+                    'type' => 'text',
+                    'placeholder' => '',
+                    'maxlength' => 40,
+                    'required' => true,
+                    'id' => 'cidade',
+                    'name' => 'cidade',
+                    'function' => false,
+                ],
+                'estado' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-2',
+                    'label' => 'Estado',
+                    'type' => 'text',
+                    'placeholder' => '',
+                    'maxlength' => 2,
+                    'required' => true,
+                    'id' => 'estado',
+                    'name' => 'estado',
+                    'function' => false,
+                ],
+                'pais' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-2',
+                    'label' => 'País',
+                    'type' => 'text',
+                    'placeholder' => '',
+                    'maxlength' => 15,
+                    'required' => true,
+                    'placeholder' => '',
+                    'id' => 'pais',
+                    'name' => 'pais',
+                    'function' => false,
+                ],
+            ],
+            'Contatos da Empresa' => [
+                'phone' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-4',
+                    'label' => 'Telefone empresarial',
+                    'type' => 'number',
+                    'placeholder' => '(00)0000-00000',
+                    'maxlength' => 14,
+                    'required' => true,
+                    'id' => 'phone',
+                    'name' => 'phone',
+                    'function' => false,
+                ],
+                'email' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-8',
+                    'label' => 'E-mail empresarial',
+                    'type' => 'email',
+                    'placeholder' => 'contato@b13company.com',
+                    'maxlength' => 70,
+                    'required' => true,
+                    'id' => 'email',
+                    'name' => 'email',
+                    'function' => false,
+                ],
+            ],
+        ],
+    ]);
+    return $data;
+  }
+}

--- a/app/Traits/MontarPagina.php
+++ b/app/Traits/MontarPagina.php
@@ -52,7 +52,10 @@ trait MontarPagina
 
     $config = new Fluent([
       'title' => 'Todos os clientes',
-      'buttonTop' => true,
+      'button_top' => [
+        'name' => '+ Cadastrar clientes',
+        'route' => 'clientes.cadastro',
+      ],
       'search' => $search,
       'actions' => $actions,
     ]);
@@ -96,7 +99,7 @@ trait MontarPagina
 
     $config = new Fluent([
       'title' => 'Todos as Empresas',
-      'buttonTop' => true,
+      'buttonTop' => false,
       'search' => $search,
       'actions' => $actions,
     ]);
@@ -140,7 +143,7 @@ trait MontarPagina
 
     $config = new Fluent([
       'title' => 'Todos os Veiculos',
-      'buttonTop' => true,
+      'buttonTop' => false,
       'search' => $search,
       'actions' => $actions,
     ]);
@@ -183,7 +186,7 @@ trait MontarPagina
 
     $config = new Fluent([
       'title' => 'Todos os Motoristas',
-      'buttonTop' => true,
+      'buttonTop' => false,
       'search' => $search,
       'actions' => $actions,
     ]);
@@ -227,7 +230,7 @@ trait MontarPagina
 
     $config = new Fluent([
       'title' => 'Todos os Segurancas',
-      'buttonTop' => true,
+      'buttonTop' => false,
       'search' => $search,
       'actions' => $actions,
     ]);

--- a/resources/views/auto-register.blade.php
+++ b/resources/views/auto-register.blade.php
@@ -1,0 +1,229 @@
+@php
+    $data = [
+        'pageInfo' => [
+            'title' => 'Cadastrar cliente',
+            'form_action' => '',
+            'form_method' => '',
+            'label_button' => 'Cadastrar cliente',
+        ],
+        'sessions' => [
+            'Dados da Empresa' => [
+                'cpf' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-6',
+                    'label' => 'CPF/CNPJ',
+                    'type' => 'text',
+                    'placeholder' => '00.000.000/0001-00',
+                    'maxlength' => 18,
+                    'required' => true,
+                    'id' => 'cpfcnpj',
+                    'name' => 'cpfcnpj',
+                    'function' => false,
+                ],
+                'apelido' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-6',
+                    'label' => 'Apelido',
+                    'type' => 'text',
+                    'placeholder' => '',
+                    'maxlength' => 50,
+                    'required' => false,
+                    'id' => 'apelido',
+                    'name' => 'apelido',
+                    'function' => false,
+                ],
+                'razao_social' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-6',
+                    'label' => 'Razão Social',
+                    'type' => 'text',
+                    'placeholder' => '',
+                    'maxlength' => 70,
+                    'required' => true,
+                    'id' => 'razao',
+                    'name' => 'razao',
+                    'function' => false,
+                ],
+                'nome_fantasia' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-6',
+                    'label' => 'Nome Fantasia',
+                    'type' => 'text',
+                    'placeholder' => '',
+                    'maxlength' => 70,
+                    'required' => true,
+                    'id' => 'nome_fantasia',
+                    'name' => 'nome_fantasia',
+                    'function' => false,
+                ],
+                'cep' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-3',
+                    'label' => 'CEP',
+                    'type' => 'number',
+                    'placeholder' => '00000-000',
+                    'maxlength' => 9,
+                    'required' => true,
+                    'id' => 'cep',
+                    'name' => 'cep',
+                    'function' => [
+                        'type' => 'onChange',
+                        'name' => 'pesquisaCep()',
+                    ],
+                ],
+                'logradouro' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-7',
+                    'label' => 'Logradouro',
+                    'type' => 'text',
+                    'placeholder' => '',
+                    'maxlength' => 50,
+                    'required' => true,
+                    'id' => 'logradouro',
+                    'name' => 'logradouro',
+                    'function' => false,
+                ],
+                'numero' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-2',
+                    'label' => 'Número',
+                    'type' => 'number',
+                    'placeholder' => '123',
+                    'maxlength' => 10,
+                    'required' => true,
+                    'id' => 'numero',
+                    'name' => 'numero',
+                    'function' => false,
+                ],
+                'bairro' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-4',
+                    'label' => 'Bairro',
+                    'type' => 'text',
+                    'placeholder' => '',
+                    'maxlength' => 30,
+                    'required' => true,
+                    'id' => 'bairro',
+                    'name' => 'bairro',
+                    'function' => false,
+                ],
+                'cidade' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-4',
+                    'label' => 'Cidade',
+                    'type' => 'text',
+                    'placeholder' => '',
+                    'maxlength' => 40,
+                    'required' => true,
+                    'id' => 'cidade',
+                    'name' => 'cidade',
+                    'function' => false,
+                ],
+                'estado' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-2',
+                    'label' => 'Estado',
+                    'type' => 'text',
+                    'placeholder' => '',
+                    'maxlength' => 2,
+                    'required' => true,
+                    'id' => 'estado',
+                    'name' => 'estado',
+                    'function' => false,
+                ],
+                'pais' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-2',
+                    'label' => 'País',
+                    'type' => 'text',
+                    'placeholder' => '',
+                    'maxlength' => 15,
+                    'required' => true,
+                    'placeholder' => '',
+                    'id' => 'pais',
+                    'name' => 'pais',
+                    'function' => false,
+                ],
+            ],
+            'Contatos da Empresa' => [
+                'phone' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-4',
+                    'label' => 'Telefone empresarial',
+                    'type' => 'number',
+                    'placeholder' => '(00)0000-00000',
+                    'maxlength' => 14,
+                    'required' => true,
+                    'id' => 'phone',
+                    'name' => 'phone',
+                    'function' => false,
+                ],
+                'email' => [
+                    'container_tag' => 'div',
+                    'container_class' => 'col-md-8',
+                    'label' => 'E-mail empresarial',
+                    'type' => 'email',
+                    'placeholder' => 'contato@b13company.com',
+                    'maxlength' => 70,
+                    'required' => true,
+                    'id' => 'email',
+                    'name' => 'email',
+                    'function' => false,
+                ],
+            ],
+        ],
+    ];
+@endphp
+
+@extends('layouts.user_type.auth')
+
+@section('content')
+
+<div>
+    <div class="container-fluid py-4">
+        <div class="card">
+            <div class="card-header pb-0 px-3">
+                <h6 class="mb-0">{{ $data['pageInfo']['title'] }}</h6>
+            </div>
+            
+            <div class="card-body pt-4 p-3">
+                <form action="{{ $data['pageInfo']['form_action'] }}" method="{{ $data['pageInfo']['form_method'] }}" role="form text-left">
+                    @csrf
+                    <div class="row">
+                        @foreach ($data['sessions'] as $key => $group)
+                            <p class="fw-bold">{{ $key }}</p>
+
+                            @foreach ($data['sessions'][$key] as $fields)
+                                <{{ $fields['container_tag'] }} class="{{ $fields['container_class'] }}">
+                                    <div class="form-group">
+                                        <label 
+                                            for="{{ $fields['id'] }}" 
+                                            class="form-control-label"
+                                        >
+                                            {{ $fields['label'] }}{{ $fields['required'] ? '*' : '' }}
+                                        </label>
+                                        <input 
+                                            class="form-control" 
+                                            type="{{ $fields['type'] }}" 
+                                            placeholder="{{ $fields['placeholder'] }}" 
+                                            id="{{ $fields['id'] }}"
+                                            name="{{ $fields['name'] }}" 
+                                            maxlength="{{ $fields['maxlength'] }}" 
+                                            {{ $fields['required'] ? 'required' : '' }}
+                                            {{ $fields['function'] ? $fields['function']['type'] . '=' . $fields['function']['name'] : '' }}
+                                        >
+                                    </div>
+                                </div>
+                            @endforeach
+                        @endforeach
+                    </div>
+                    <div class="d-flex justify-content-end">
+                        <button type="submit" class="btn bg-gradient-primary btn-md mt-4 mb-4">{{ $data['pageInfo']['label_button'] }}</button>
+                    </div>
+                </form>
+
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/cadastro.blade.php
+++ b/resources/views/cadastro.blade.php
@@ -1,0 +1,31 @@
+@extends('layouts.user_type.auth')
+
+@section('content')
+
+<div>
+    <div class="container-fluid py-4">
+        <div class="card">
+            <div class="card-header pb-0 px-3">
+                <h6 class="mb-0">{{ $dados['pageInfo']['title'] }}</h6>
+            </div>
+            
+            <div class="card-body pt-4 p-3">
+                <form action="{{ $dados['pageInfo']['form_action'] }}" method="{{ $dados['pageInfo']['form_method'] }}" role="form text-left">
+                    @csrf
+                    <div class="row">
+                        @foreach ($dados['sessions'] as $key => $group)
+                            <p class="fw-bold">{{ $key }}</p>
+
+                            @include('register.formRegister');
+                        @endforeach
+                    </div>
+                    <div class="d-flex justify-content-end">
+                        <button type="submit" class="btn bg-gradient-primary btn-md mt-4 mb-4">{{ $dados['pageInfo']['label_button'] }}</button>
+                    </div>
+                </form>
+
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/listagem.blade.php
+++ b/resources/views/listagem.blade.php
@@ -76,10 +76,10 @@
               </div>
               <!-- FIM TÍTULO TABELA -->
               <!-- BOTÃO CADASTRAR -->
-              @if ( $config->buttonTop ) 
+              @if ( $config->button_top ) 
                 <div class="col-md-6 text-end">
                   <div class="card-header pb-0">
-                    <a href="#" class="btn bg-gradient-info mt-4 mb-0">+ Cadastrar</a>
+                    <a href="{{ route($config->button_top['route']) }}" class="btn bg-gradient-info mt-4 mb-0">{{ $config->button_top['name'] }}</a>
                   </div>
                 </div> 
               @endif

--- a/resources/views/register/formRegister.blade.php
+++ b/resources/views/register/formRegister.blade.php
@@ -1,0 +1,22 @@
+@foreach ($dados['sessions'][$key] as $fields)
+    <{{ $fields['container_tag'] }} class="{{ $fields['container_class'] }}">
+        <div class="form-group">
+            <label 
+                for="{{ $fields['id'] }}" 
+                class="form-control-label"
+            >
+                {{ $fields['label'] }}{{ $fields['required'] ? '*' : '' }}
+            </label>
+            <input 
+                class="form-control" 
+                type="{{ $fields['type'] }}" 
+                placeholder="{{ $fields['placeholder'] }}" 
+                id="{{ $fields['id'] }}"
+                name="{{ $fields['name'] }}" 
+                maxlength="{{ $fields['maxlength'] }}" 
+                {{ $fields['required'] ? 'required' : '' }}
+                {{ $fields['function'] ? $fields['function']['type'] . '=' . $fields['function']['name'] : '' }}
+            >
+        </div>
+    </div>
+@endforeach

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,6 +35,7 @@ Route::group(['middleware' => 'auth'], function () {
 		return view('dashboard');
 	})->name('dashboard');
 
+	//LISTAGEM
 	Route::prefix('clientes')->group(function () {
 		Route::get('/', [ClientesController::class, 'index'])->name('clientes.index');
 		Route::get('/listar', [ClientesController::class, 'listar'])->name('clientes.listar');
@@ -58,6 +59,12 @@ Route::group(['middleware' => 'auth'], function () {
 	Route::prefix('segurancas')->group(function () {
 		Route::get('/', [SegurancasController::class, 'index'])->name('segurancas.index');
 		Route::get('/listar', [SegurancasController::class, 'listar'])->name('segurancas.listar');
+	});
+
+	Route::prefix('clientes')->group(function () {
+		Route::get('/', [ClientesController::class, 'index'])->name('clientes.index');
+		Route::get('/listar', [ClientesController::class, 'listar'])->name('clientes.listar');
+		Route::get('/cadastro', [ClientesController::class, 'cadastro'])->name('clientes.cadastro');
 	});
 
 
@@ -92,6 +99,10 @@ Route::group(['middleware' => 'auth'], function () {
 	Route::get('static-sign-up', function () {
 		return view('static-sign-up');
 	})->name('sign-up');
+
+	Route::get('auto-register', function () {
+		return view('auto-register');
+	})->name('auto-register');
 
 	Route::get('/logout', [SessionsController::class, 'destroy']);
 	Route::get('/user-profile', [InfoUserController::class, 'create']);


### PR DESCRIPTION
Criei a estrutura de tela de cadastros. Vamos precisar implementar o campo value para que ela se torne também a estrutura de edição. A lógica aqui foi:

1. A rota cadastro chama 
2. ClientesController que aciona a função cadastro. A função cadastro pega os dados da
3. Traits > MontarForm e retorna o array gigantesco que monta cada input. Com esses dados, a função cadastro chama a view
4. Cadastro.blade.php que monta a estrutura da página e inclui a lógica de inserir os campos do arquivo
5. views > register > formRegister . Esse arquivo contém o foreach que percorre e monta todos os inputs.

Eu tentei seguir a mesma lógica que você seguiu na tabela mas, algumas coisas não consegui entender 100% e, tentei me aventurar mas não deu certo, então fiz como entendi. 

Vamos precisar incluir alguns campos no array de cadastro para comportar: 
1. Campo de dados bancários;
2. Cadastro de contatos;
3. Cadastro de adicionais; 
4. Cadastro de especialização;
Como os dados acima serão sempre iguais (onde vão ser repetidos) eu pensei em criar apenas 4 novos campos no array (para cada item da lista) com true ou false e, caso seja true, ele simplesmente vai chamar uma lógica que puxa esse componente.

Pq eu não fiz isso ainda? Pq queria conversar com você sobre se vamos conseguir utilizar essa lógica de cadastro para edição também, ou você prefere criar uma outra (o que eu não acho válido mas, conto com a sua experiência). O que pode complicar mais para gente os campos de edição são exatamente esses campos adicionais, popular e montar eles na página de edição pode ser mais chatinho.

Acredito que os demais forms de cadastro, inclusive aqueles com select preenchido e tudo o mais vai ser bem fácil de resolver. Talvez só o do orçamentos e O.S precisaremos fazer separado, mas, vamos analisando.