### PR TITLE
AJUSTES

### DIFF
--- a/app/Livewire/OS/CampoServico.php
+++ b/app/Livewire/OS/CampoServico.php
@@ -106,6 +106,11 @@ class CampoServico extends Component
         }
 
         $this->{$type} = $value;
+
+        if ($type == 'typesVehicle') {
+            $this->updatedTypesVehicle($value);
+        }
+
         $this->updateServiceData();
     }
 
@@ -129,6 +134,11 @@ class CampoServico extends Component
         if (in_array($property, ['id_category_service', 'vehiclesCategory', 'typesVehicle', 'securityType', 'armored', 'bilingue', 'qtdHoras', 'driver'])) {
             $this->updateServiceData();
         }
+    }
+
+    public function updatedTypesVehicle($value)
+    {
+        $this->dispatch('typesVehicleUpdated', $value, $this->serviceId);
     }
 
     private function buscarServicoCadastrado()

--- a/app/Livewire/OS/MotoristaItem.php
+++ b/app/Livewire/OS/MotoristaItem.php
@@ -6,6 +6,7 @@ use App\Livewire\SelectComponent;
 use App\Models\OsEmployeeVehicle;
 use App\Models\OsExecution;
 use App\Models\OsService;
+use App\Models\Vehicle;
 use Carbon\Carbon;
 use Livewire\Attributes\On;
 use Livewire\Component;
@@ -24,6 +25,7 @@ class MotoristaItem extends Component
 
     public $serviceId;
     public $motoristaId;
+    public $vehicleCompany;
 
     public $typesVehicle;
     public $targetClass = MotoristaItem::class;
@@ -80,6 +82,10 @@ class MotoristaItem extends Component
 
             if ($motoristaId == $this->motoristaId) {
                 $this->{$type} = $value;
+
+                if ($type == 'vehicles_plate') {
+                    $this->vehicleCompany = Vehicle::find($value)?->id_company;
+                }
             }
         }
     }

--- a/app/Livewire/OS/MotoristaItem.php
+++ b/app/Livewire/OS/MotoristaItem.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\OS;
 
+use App\Livewire\SelectComponent;
 use App\Models\OsEmployeeVehicle;
 use App\Models\OsExecution;
 use App\Models\OsService;
@@ -24,6 +25,7 @@ class MotoristaItem extends Component
     public $serviceId;
     public $motoristaId;
 
+    public $typesVehicle;
     public $targetClass = MotoristaItem::class;
 
     public function mount($motorista = null)
@@ -31,6 +33,11 @@ class MotoristaItem extends Component
         if ($motorista) {
             $this->motoristaId = $motorista['id'];
             $this->serviceId = $motorista['serviceId'];
+
+            if ($this->serviceId) {
+                $services = OsService::find($this->serviceId);
+                $this->typesVehicle = $services->service->vehicleType->id ?? '';
+            }
 
             $motoristaCadastrado = OsEmployeeVehicle::find($motorista['id']);
 
@@ -44,6 +51,15 @@ class MotoristaItem extends Component
                 $this->end = $motoristaCadastrado->end;
             }
         }
+    }
+
+    #[On('typesVehicleUpdated')]
+    public function updatedtypesVehicle($value, $serviceId)
+    {
+        if ($serviceId != $this->serviceId) {
+            return $this->skipRender();
+        }
+        $this->typesVehicle = $value;
     }
 
     public function deleteMotorista($motoristaId)

--- a/app/Livewire/SelectComponent.php
+++ b/app/Livewire/SelectComponent.php
@@ -14,6 +14,7 @@ use App\Models\Employee;
 use Livewire\Component;
 use Illuminate\Support\Facades\Http;
 use Livewire\Attributes\Modelable;
+use Livewire\Attributes\On;
 
 class SelectComponent extends Component
 {
@@ -24,11 +25,11 @@ class SelectComponent extends Component
     public $selected;
     public $selectedPrimaryId;
     public $type;
-    public $filterByTypeId = null;
+    public $filter = null;
     public $target = null;
     public $targetClass = null;
 
-    public function mount($type, $placeholder, $name, $selected, $filterByTypeId = null, $targetClass = null)
+    public function mount($type, $placeholder, $name, $selected, $filter = null, $targetClass = null)
     {
         $this->type = $type;
 
@@ -36,11 +37,18 @@ class SelectComponent extends Component
             $this->{$type} = $selected;
         }
 
+        $this->getOptionsProperty();
+
         $this->name = $name;
         $this->selected = $selected ?? null;
         $this->targetClass = $targetClass;
 
-        $this->options = match ($type) {
+        $this->filter = $filter; // Armazenar o ID do tipo de veículo
+    }
+
+    public function getOptionsProperty()
+    {
+        $this->options = match ($this->type) {
             'especialization' => $this->especialization(),
             'especialization_primary' => $this->especialization(true),
             'especialization_general' => $this->especializationGeneral(true),
@@ -68,7 +76,6 @@ class SelectComponent extends Component
             'paymentMethod' => $this->paymentMethod(),
             default => $this->especialization(),
         };
-        $this->filterByTypeId = $filterByTypeId; // Armazenar o ID do tipo de veículo
     }
 
     public function render()
@@ -258,8 +265,8 @@ class SelectComponent extends Component
     {
         return Vehicle::select('vehicles.id', 'vehicles.plate', 'vehicle_brands.name as brand_name', 'vehicles.model')
             ->join('vehicle_brands', 'vehicles.id_brand', '=', 'vehicle_brands.id')
-            ->when($this->filterByTypeId, function ($query) { // Filtrar pelo tipo de veículo, se fornecido
-                $query->where('vehicles.id_type', $this->filterByTypeId);
+            ->when($this->filter, function ($query) {
+                $query->where('id_type', $this->filter);
             })
             ->orderBy('vehicle_brands.name', 'asc')
             ->get();

--- a/app/Livewire/SelectComponent.php
+++ b/app/Livewire/SelectComponent.php
@@ -30,11 +30,14 @@ class SelectComponent extends Component
     public $filter = null;
     public $target = null;
     public $targetClass = null;
+    public $search = false;
+    public $searchTerm = '';
 
-    public function mount($type, $placeholder, $name, $selected, $filter = [], $targetClass = null)
+    public function mount($type, $placeholder, $name, $selected, $filter = [], $targetClass = null, $search = false)
     {
         $this->type = $type;
 
+        $this->search = $search;
         $this->name = $name;
         $this->selected = $selected ?? null;
         $this->targetClass = $targetClass;
@@ -299,6 +302,11 @@ class SelectComponent extends Component
             }
         }
 
+        if ($this->search && $this->searchTerm) {
+            $query->where(function ($q) {
+                $q->where('name', 'like', '%' . $this->searchTerm . '%');
+            });
+        }
 
         return $query;
     }
@@ -306,6 +314,11 @@ class SelectComponent extends Component
     protected function isRelationship($model, $key)
     {
         return method_exists($model, $key) && is_a($model->{$key}(), Relation::class);
+    }
+
+    public function updatedSearchTerm($value)
+    {
+        $this->getOptionsProperty();
     }
 
     public function updatingSelected($value)

--- a/app/Livewire/SelectComponent.php
+++ b/app/Livewire/SelectComponent.php
@@ -11,6 +11,7 @@ use App\Models\Vehicle;
 use App\Models\VehicleBrand;
 use App\Models\VehicleType;
 use App\Models\Employee;
+use Illuminate\Database\Eloquent\Builder;
 use Livewire\Component;
 use Illuminate\Support\Facades\Http;
 use Livewire\Attributes\Modelable;
@@ -29,26 +30,22 @@ class SelectComponent extends Component
     public $target = null;
     public $targetClass = null;
 
-    public function mount($type, $placeholder, $name, $selected, $filter = null, $targetClass = null)
+    public function mount($type, $placeholder, $name, $selected, $filter = [], $targetClass = null)
     {
         $this->type = $type;
-
-        if ($selected) {
-            $this->{$type} = $selected;
-        }
-
-        $this->getOptionsProperty();
 
         $this->name = $name;
         $this->selected = $selected ?? null;
         $this->targetClass = $targetClass;
 
-        $this->filter = $filter; // Armazenar o ID do tipo de veículo
+        $this->filter = $filter;
+
+        $this->getOptionsProperty();
     }
 
     public function getOptionsProperty()
     {
-        $this->options = match ($this->type) {
+        $query = match ($this->type) {
             'especialization' => $this->especialization(),
             'especialization_primary' => $this->especialization(true),
             'especialization_general' => $this->especializationGeneral(true),
@@ -76,6 +73,14 @@ class SelectComponent extends Component
             'paymentMethod' => $this->paymentMethod(),
             default => $this->especialization(),
         };
+
+
+        if ($query instanceof Builder) {
+            $filteredQuery = $this->createFilter($query);
+            $this->options = $filteredQuery->get();
+        } else {
+            $this->options = $query;
+        }
     }
 
     public function render()
@@ -90,8 +95,7 @@ class SelectComponent extends Component
         return Specialization::select('id', 'name')
             ->orderBy('name', 'ASC')
             ->when($primary, fn($query) => $query->whereNull('id_ascendent'))
-            ->when(!$primary, fn($query) => $query->where('id_ascendent', $selectedPrimaryId))
-            ->get();
+            ->when(!$primary, fn($query) => $query->where('id_ascendent', $selectedPrimaryId));
     }
 
     public function especializationGeneral()
@@ -100,69 +104,60 @@ class SelectComponent extends Component
         return Specialization::select('id', 'name')
             ->orderBy('name', 'ASC')
             ->whereNotNull('id_ascendent')
-            ->where('id_ascendent', '!=', 1)
-            ->get();
+            ->where('id_ascendent', '!=', 1);
     }
 
     public function languages()
     {
         return Specialization::select('id', 'name')
             ->where('id_ascendent', 1)
-            ->orderBy('name', 'ASC')
-            ->get();
+            ->orderBy('name', 'ASC');
     }
 
     public function empresas()
     {
         return Company::select('id', 'name')
-            ->orderBy('name', 'ASC')
-            ->get();
+            ->orderBy('name', 'ASC');
     }
 
     public function typesVehicle()
     {
         return VehicleType::select('id', 'name')
-            ->orderBy('name', 'ASC')
-            ->get();
+            ->orderBy('name', 'ASC');
     }
 
     public function categoryVehicle()
     {
         return Category::select('id', 'name')
             ->whereHas('type', fn($query) => $query->where('name', 'Vehicle'))
-            ->orderBy('name', 'ASC')
-            ->get();
+            ->orderBy('name', 'ASC');
     }
 
     public function categoryService()
     {
         return Category::select('id', 'name')
             ->whereHas('type', fn($query) => $query->where('name', 'Service'))
-            ->orderBy('name', 'ASC')
-            ->get();
+            ->orderBy('name', 'ASC');
     }
 
     public function securityType()
     {
         return Category::select('id', 'name')
             ->whereHas('type', fn($query) => $query->where('name', 'Security'))
-            ->orderBy('name', 'ASC')
-            ->get();
+            ->orderBy('name', 'ASC');
     }
 
     public function employee($type)
     {
         return Employee::select('id', 'name')
             ->where('type', $type)
-            ->orderBy('name', 'ASC')
-            ->get();
+            ->orderBy('name', 'ASC');
     }
 
     public function brands()
     {
         return VehicleBrand::select('id', 'name')
-            ->orderBy('name', 'ASC')
-            ->get();
+            ->orderBy('name', 'ASC');
     }
 
     public function armored()
@@ -219,62 +214,70 @@ class SelectComponent extends Component
     {
         return Category::select('id', 'name')
             ->whereHas('type', fn($query) => $query->where('name', 'Service'))
-            ->orderBy('created_at', 'desc')
-            ->get();
+            ->orderBy('created_at', 'desc');
     }
 
     public function servicesOS()
     {
         return Service::select('id', 'name')
-            ->orderBy('created_at', 'desc')
-            ->get();
+            ->orderBy('created_at', 'desc');
     }
 
     public function servicesOSLoc()
     {
         return Service::select('id', 'name')
             ->where('id_service_type', 1)
-            ->orderBy('created_at', 'desc')
-            ->get();
+            ->orderBy('created_at', 'desc');
     }
 
     public function servicesOSSeg()
     {
         return Service::select('id', 'name')
             ->where('id_service_type', 2)
-            ->orderBy('created_at', 'desc')
-            ->get();
+            ->orderBy('created_at', 'desc');
     }
 
     public function vehiclesCategory()
     {
         return Category::select('id', 'name')
             ->whereHas('type', fn($query) => $query->where('name', 'Vehicle'))
-            ->orderBy('created_at', 'desc')
-            ->get();
+            ->orderBy('created_at', 'desc');
     }
 
     public function vehicles()
     {
         return Vehicle::select('id', 'name')
-            ->orderBy('created_at', 'desc')
-            ->get();
+            ->orderBy('created_at', 'desc');
     }
 
     public function vehiclesBrandPlate()
     {
         return Vehicle::select('vehicles.id', 'vehicles.plate', 'vehicle_brands.name as brand_name', 'vehicles.model')
             ->join('vehicle_brands', 'vehicles.id_brand', '=', 'vehicle_brands.id')
-            ->when($this->filter, function ($query) {
-                $query->where('id_type', $this->filter);
-            })
-            ->orderBy('vehicle_brands.name', 'asc')
-            ->get();
+            ->orderBy('vehicle_brands.name', 'asc');
     }
 
     public function paymentMethod()
     {
-        return PaymentMethod::select('id', 'description as name')->get();
+        return PaymentMethod::select('id', 'description as name');
+    }
+
+    public function createFilter($query)
+    {
+        if (!$this->filter) {
+            return $query;
+        }
+
+        foreach ($this->filter as $key => $value) {
+
+            if (is_array($value)) {
+                $query->whereIn($key, $value);
+            } elseif ($value) {
+                $query->where($key, $value);
+            }
+        }
+
+        return $query;
     }
 
     public function updatingSelected($value)

--- a/app/Models/Specialization.php
+++ b/app/Models/Specialization.php
@@ -17,6 +17,11 @@ class Specialization extends Model
         return $this->hasMany(Specialization::class, 'id_ascendent', 'id');
     }
 
+    public function parent()
+    {
+        return $this->belongsTo(Specialization::class, 'id_ascendent', 'id');
+    }
+
     public function drivers()
     {
         return $this->hasManyThrough(

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "php": "^8.1",
         "dompdf/dompdf": "^3.0",
         "guzzlehttp/guzzle": "^7.2",
+        "itsgoingd/clockwork": "^5.2",
         "laravel/framework": "^10.10",
         "laravel/sanctum": "^3.3",
         "laravel/tinker": "^2.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d744deaabb5b4a0412529c30030153b2",
+    "content-hash": "5996e58de43288728c05a08928cd2eba",
     "packages": [
         {
             "name": "brick/math",
@@ -1204,6 +1204,81 @@
                 }
             ],
             "time": "2023-12-03T19:50:20+00:00"
+        },
+        {
+            "name": "itsgoingd/clockwork",
+            "version": "v5.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/itsgoingd/clockwork.git",
+                "reference": "29bc4cedfbe742b419544c30b7b6e15cd9da08ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/itsgoingd/clockwork/zipball/29bc4cedfbe742b419544c30b7b6e15cd9da08ef",
+                "reference": "29bc4cedfbe742b419544c30b7b6e15cd9da08ef",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=5.6"
+            },
+            "suggest": {
+                "ext-pdo": "Needed in order to use a SQL database for metadata storage",
+                "ext-pdo_mysql": "Needed in order to use MySQL for metadata storage",
+                "ext-pdo_postgres": "Needed in order to use Postgres for metadata storage",
+                "ext-pdo_sqlite": "Needed in order to use a SQLite for metadata storage",
+                "ext-redis": "Needed in order to use Redis for metadata storage"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Clockwork\\Support\\Laravel\\ClockworkServiceProvider"
+                    ],
+                    "aliases": {
+                        "Clockwork": "Clockwork\\Support\\Laravel\\Facade"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Clockwork\\": "Clockwork/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "itsgoingd",
+                    "email": "itsgoingd@luzer.sk",
+                    "homepage": "https://twitter.com/itsgoingd"
+                }
+            ],
+            "description": "php dev tools in your browser",
+            "homepage": "https://underground.works/clockwork",
+            "keywords": [
+                "Devtools",
+                "debugging",
+                "laravel",
+                "logging",
+                "lumen",
+                "profiling",
+                "slim"
+            ],
+            "support": {
+                "issues": "https://github.com/itsgoingd/clockwork/issues",
+                "source": "https://github.com/itsgoingd/clockwork/tree/v5.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/itsgoingd",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-04-14T10:49:22+00:00"
         },
         {
             "name": "laravel/framework",

--- a/resources/views/livewire/o-s/cadastro.blade.php
+++ b/resources/views/livewire/o-s/cadastro.blade.php
@@ -122,5 +122,21 @@
             const tabs = document.querySelectorAll('#myTab .nav-link');
             
         });
+
+        $wire.on('alert', (data) => {
+            data = data[0]
+            Toastify({
+                    text: data.message,
+                    className: data.type,
+                    close: true,
+                    gravity: "bottom",
+                    position: "right",
+                    style: {
+                    background: data.type === 'warning' ? '#ff4c4c' : '#FF9921',
+
+                }   
+            }).showToast();
+        });
+
     </script>
 @endscript

--- a/resources/views/livewire/o-s/motorista-itens.blade.php
+++ b/resources/views/livewire/o-s/motorista-itens.blade.php
@@ -88,6 +88,7 @@
 				targetClass="{{$targetClass}}"
 				selected='{{$employee_driver ?? null}}' 
 				targetClass="{{$targetClass}}"
+				search="true"
 			/>
 		</div>
 	

--- a/resources/views/livewire/o-s/motorista-itens.blade.php
+++ b/resources/views/livewire/o-s/motorista-itens.blade.php
@@ -25,14 +25,14 @@
 		<div class="mb-3 tw-w-[50%]">
 			<label for="company">Empresa</label>
 			<livewire:select-component
-				wire:key="empresas-{{data_get($motorista, 'id')}}"
+				wire:key="empresas-{{data_get($motorista, 'id') . $vehicleCompany }}"
 				target="cadastro_motorista-{{data_get($motorista, 'id')}}"
 				type="empresas"
 				placeholder="Selecione a empresa"    
 				name="empresas[]" 
 				id="empresas"
 				targetClass="{{$targetClass}}"
-				selected="{{$empresas ?? null}}" 
+				selected="{{$vehicleCompany ?? $empresas ?? null}}" 
 			/> 
 		</div>
 		<div class="mb-3 tw-w-[25%] tw-pr-[8px]">

--- a/resources/views/livewire/o-s/motorista-itens.blade.php
+++ b/resources/views/livewire/o-s/motorista-itens.blade.php
@@ -78,12 +78,13 @@
 		<div class="mb-3 tw-w-[25%]">
 			<label for="motoristaVeiculo">Motorista</label>
 			<livewire:select-component
-				wire:key="employee_driver-{{data_get($motorista, 'id')}}"
+				wire:key="employee_driver-{{data_get($motorista, 'id') . $especialization_general . $languages}}"
 				type="employee_driver"
 				target="cadastro_motorista-{{data_get($motorista, 'id')}}"
 				placeholder="Selecione o motorista"
 				name="employee[]"
 				id="employee"
+				:filter="['specializations' => ['id1' => $especialization_general, 'id2' => $languages]]"
 				targetClass="{{$targetClass}}"
 				selected='{{$employee_driver ?? null}}' 
 				targetClass="{{$targetClass}}"

--- a/resources/views/livewire/o-s/motorista-itens.blade.php
+++ b/resources/views/livewire/o-s/motorista-itens.blade.php
@@ -38,14 +38,14 @@
 		<div class="mb-3 tw-w-[25%] tw-pr-[8px]">
 			<label for="modeloVeiculo">Modelo de veículo</label>
 			<livewire:select-component 
-				wire:key="vehicleModel-{{data_get($motorista, 'id')}}"
+				wire:key="vehicleModel-{{data_get($motorista, 'id') . $typesVehicle}}"
 				type="vehicles_plate" 
 				target="cadastro_motorista-{{data_get($motorista, 'id')}}"
 				placeholder="Selecione o modelo do veículo" 
 				name="vehicleModel[]" 
 				id="vehicleModel" 
 				:selected="$vehicles_plate ?? null" 
-				:filter-by-type="$typesVehicle ?? ''"  
+				:filter="$typesVehicle"  
 				targetClass="{{$targetClass}}"
 			/> 
 		</div>

--- a/resources/views/livewire/o-s/motorista-itens.blade.php
+++ b/resources/views/livewire/o-s/motorista-itens.blade.php
@@ -38,14 +38,14 @@
 		<div class="mb-3 tw-w-[25%] tw-pr-[8px]">
 			<label for="modeloVeiculo">Modelo de veículo</label>
 			<livewire:select-component 
-				wire:key="vehicleModel-{{data_get($motorista, 'id') . $typesVehicle}}"
+				wire:key="vehicleModel-{{data_get($motorista, 'id') . $typesVehicle . $empresas}}"
 				type="vehicles_plate" 
 				target="cadastro_motorista-{{data_get($motorista, 'id')}}"
 				placeholder="Selecione o modelo do veículo" 
 				name="vehicleModel[]" 
 				id="vehicleModel" 
 				:selected="$vehicles_plate ?? null" 
-				:filter="$typesVehicle"  
+				:filter="['id_type' => $typesVehicle, 'id_company' => $empresas]"  
 				targetClass="{{$targetClass}}"
 			/> 
 		</div>

--- a/resources/views/livewire/select-component.blade.php
+++ b/resources/views/livewire/select-component.blade.php
@@ -1,5 +1,5 @@
 <div>
-    <select class="dinamicSelect form-control" name="{{ $name }}" id="{{ $name }}" wire:model.live="selected">
+    <select wire:key="{{ $type .'-'.$filter }}" class="dinamicSelect form-control" name="{{ $name }}" id="{{ $name }}" wire:model.live="selected">
         <option value="">{{ $placeholder }}</option>
         @foreach ($options as $option)
             <option value="{{ $option->id }}">

--- a/resources/views/livewire/select-component.blade.php
+++ b/resources/views/livewire/select-component.blade.php
@@ -1,5 +1,5 @@
-<div>
-    <select  class="dinamicSelect form-control" name="{{ $name }}" id="{{ $name }}" wire:model.live="selected">
+<div wire:ignore>
+    <select  class="@if($search)search @else dinamicSelect form-control  @endif" name="{{ $name }}" id="{{ $name }}" wire:model.live="selected">
         <option value="">{{ $placeholder }}</option>
         @foreach ($options as $option)
             <option value="{{ $option->id }}">
@@ -12,3 +12,29 @@
         @endforeach
     </select>
 </div>
+
+@script
+    <script>
+        
+        $(document).ready(function() {
+            const selects = document.querySelectorAll(".search")
+            
+            selects.forEach(select => {
+                new TomSelect(select,{
+                    allowEmptyOption: true,
+                    create: false,
+                    sortField: {
+                        field: "text",
+                        direction: "asc"
+                    },
+                    onInitialize: function() {
+                        this.clear(true); // Limpa a seleção inicial
+                    },
+                    onType: function(str) {
+                        @this.set('searchTerm', str);
+                    }
+                }) 
+            })
+        });
+    </script>
+@endscript

--- a/resources/views/livewire/select-component.blade.php
+++ b/resources/views/livewire/select-component.blade.php
@@ -1,5 +1,5 @@
 <div>
-    <select wire:key="{{ $type .'-'.$filter }}" class="dinamicSelect form-control" name="{{ $name }}" id="{{ $name }}" wire:model.live="selected">
+    <select wire:key="{{ $type .'-'. implode('-', $filter) }}" class="dinamicSelect form-control" name="{{ $name }}" id="{{ $name }}" wire:model.live="selected">
         <option value="">{{ $placeholder }}</option>
         @foreach ($options as $option)
             <option value="{{ $option->id }}">

--- a/resources/views/livewire/select-component.blade.php
+++ b/resources/views/livewire/select-component.blade.php
@@ -1,5 +1,5 @@
 <div>
-    <select wire:key="{{ $type .'-'. implode('-', $filter) }}" class="dinamicSelect form-control" name="{{ $name }}" id="{{ $name }}" wire:model.live="selected">
+    <select  class="dinamicSelect form-control" name="{{ $name }}" id="{{ $name }}" wire:model.live="selected">
         <option value="">{{ $placeholder }}</option>
         @foreach ($options as $option)
             <option value="{{ $option->id }}">

--- a/storage/clockwork/.gitignore
+++ b/storage/clockwork/.gitignore
@@ -1,0 +1,3 @@
+*.json
+*.json.gz
+index


### PR DESCRIPTION
- Agora é possivel passar multiplos filtros ao select.

`:filter="['id_type' => $typesVehicle, 'id_company' => $empresas]" `

Modo de usar:
Você passa a coluna do filtro, e o valor a ser usado no filtro. O valor pode ser um array de valores.EX:
`:filter="['id_type' => $typesVehicle, 'id_company' =>[1,3,5]]" `

----
**Updates**

Ajuste também no filtro, agora aceita relacionamento
`:filter="['specializations' => ['id1' => $especialization_general, 'id2' => $languages]]"`

No caso como a coluna era id para ambos no mesmo relacionamento, precisa passar com numeração, isso é tratdo e removido no backend. Caso os valores dos ids seja inclusivos ( um ou outro), pode passar todos dentro de um array tipo:
'id' => [$especialization_general, $languages]

Como num caso de filtro os valores precisam ser exatos, precisa passar assim.

O uso de relacionamento no filtro é necessário pois estamos filtrando atraves dele, no caso de motorista x especialização. E a filtragem esta sendo gerada dinamicamente para todos os componentes.

**NECESSARIO TESTAGEM NO SISTEMA TODO DEVIDO A COMPLEXIDADE E AMPLITUDE DA MUDANÇA**

-----
- RODAR

`sail componser install`

Instalado clockwork para debug de queries e outros. Basta acessar
localhost/clockwork

Com isso você consegue ver as queries que estão sendo gerados pelo eloquent.

![image](https://github.com/user-attachments/assets/e778cfd8-a37c-47d4-9b24-8e264a8a1022)


